### PR TITLE
fix typo in dependencies.md

### DIFF
--- a/book/introduction/dependencies.md
+++ b/book/introduction/dependencies.md
@@ -22,7 +22,7 @@ You can achieve synchronous connection pooling with `r2d2-postgres` without any 
 ### Async
 * Client: `cornucopia_async`.
 * Runtime: `tokio`.
-* Driver: `tokio_postgres`.
+* Driver: `tokio-postgres`.
 * Async tools: `futures`.
 
 #### (Optional) Async connection pooling


### PR DESCRIPTION
fix typo in `dependencies.md` which leads to an unresolved dependency when copied into `Cargo.toml` blindly - correct me if I am wrong though.